### PR TITLE
Generate json graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+DS_Store
+.RData
+.Rhistory

--- a/OaklandSankey.R
+++ b/OaklandSankey.R
@@ -1,15 +1,13 @@
-
-
 #########
 
 library(pacman)
 p_load(RSocrata, networkD3, magrittr)
 #Budget
 budget <- read.socrata("https://data.oaklandnet.com/resource/w4j2-chmt.csv")    
-    #Make 15-16 Budget
-    newbudget <- budget %>% dplyr::filter(Fiscal.Year == "FY15-16") %>% dplyr::select( Expense.or.Revenue, Department, Fund, Account.Type, Value)
-    newbudget$Department <- as.character(newbudget$Department)
-    newbudget$Account.Type <- as.character(newbudget$Account.Type)
+#Make 15-16 Budget
+newbudget <- budget %>% dplyr::filter(Fiscal.Year == "FY15-16") %>% dplyr::select( Expense.or.Revenue, Department, Fund, Account.Type, Value)
+newbudget$Department <- as.character(newbudget$Department)
+newbudget$Account.Type <- as.character(newbudget$Account.Type)
 #Make General Fund
 generalfund <- newbudget %>% dplyr::filter(Fund == 1010)
 
@@ -59,24 +57,24 @@ newdf <- dplyr::left_join(df, lookUp, by="name")
 
 #re-write source
 for (i in seq(along = newdf$source)) {
-    
-    if(newdf$source[i] <= 39) {
-        newdf$source[i] <- newdf$source[i]
-    } else {
-        newdf$source[i] <- newdf$id[i]
-    }
-    
+  
+  if(newdf$source[i] <= 39) {
+    newdf$source[i] <- newdf$source[i]
+  } else {
+    newdf$source[i] <- newdf$id[i]
+  }
+  
 }
 
 #re-write target
 for (i in seq(along = newdf$target)) {
-    
-    if(newdf$target[i] <= 39) {
-        newdf$target[i] <- newdf$target[i]
-    } else {
-        newdf$target[i] <- newdf$id[i]
-    }
-    
+  
+  if(newdf$target[i] <= 39) {
+    newdf$target[i] <- newdf$target[i]
+  } else {
+    newdf$target[i] <- newdf$id[i]
+  }
+  
 }
 #### Data wrangling end
 
@@ -84,6 +82,13 @@ for (i in seq(along = newdf$target)) {
 nodes <- data.frame(name = c(unique(newdf$name),"General Fund", "Non-Discretionary"), stringsAsFactors = F)
 links <- data.frame(source = newdf$source, target = newdf$target, value = newdf$value/1000000, stringsAsFactors = F)
 sankeyDF <- list(nodes = nodes, links = links)
+
+### Write out the graph data to a json file as well
+library(jsonlite)
+graphJSON <- toJSON(sankeyDF, pretty=TRUE)
+# cat(graphJSON)
+write(graphJSON, "graph.json")
+
 #Publish Sankey
 sankeyPlot <- sankeyNetwork(Links = sankeyDF$links, Nodes = sankeyDF$nodes, Source = "source",
               Target = "target", Value = "value", NodeID = "name", units = "$M", colourScale = JS("d3.scale.category20c()"),

--- a/OaklandSankey.R
+++ b/OaklandSankey.R
@@ -20,7 +20,7 @@ gf_expenses$target <- rep(100,nrow(gf_expenses))
 names(gf_expenses) <- c("name", "value", "source", "target")
 
 
-#Make General Fun Revenues
+#Make General Fund Revenues
 gf_revenues <- dplyr::filter(generalfund,Expense.or.Revenue=="Revenue")
 gf_revenues  <- aggregate(gf_revenues$Value, by=list(Account=gf_revenues$Account.Type), FUN=sum)
 gf_revenues$source <- rep(101, nrow(gf_revenues))
@@ -83,7 +83,7 @@ nodes <- data.frame(name = c(unique(newdf$name),"General Fund", "Non-Discretiona
 links <- data.frame(source = newdf$source, target = newdf$target, value = newdf$value/1000000, stringsAsFactors = F)
 sankeyDF <- list(nodes = nodes, links = links)
 
-### Write out the graph data to a json file as well
+### Write out the graph data to a json file
 library(jsonlite)
 graphJSON <- toJSON(sankeyDF, pretty=TRUE)
 # cat(graphJSON)

--- a/graph.json
+++ b/graph.json
@@ -1,0 +1,461 @@
+{
+  "nodes": [
+    {
+      "name": "Capital Improvement Projects"
+    },
+    {
+      "name": "City Administrator"
+    },
+    {
+      "name": "City Attorney"
+    },
+    {
+      "name": "City Auditor"
+    },
+    {
+      "name": "City Clerk"
+    },
+    {
+      "name": "City Council"
+    },
+    {
+      "name": "Economic & Workforce Development"
+    },
+    {
+      "name": "Finance"
+    },
+    {
+      "name": "Fire"
+    },
+    {
+      "name": "Human Resources Management"
+    },
+    {
+      "name": "Human Services"
+    },
+    {
+      "name": "Information Technology"
+    },
+    {
+      "name": "Mayor"
+    },
+    {
+      "name": "Non-Departmental"
+    },
+    {
+      "name": "Oakland Parks & Recreation"
+    },
+    {
+      "name": "Oakland Public Library"
+    },
+    {
+      "name": "Oakland Public Works"
+    },
+    {
+      "name": "Planning & Building"
+    },
+    {
+      "name": "Police"
+    },
+    {
+      "name": "Business License Tax"
+    },
+    {
+      "name": "Fines & Penalties"
+    },
+    {
+      "name": "Grants & Subsidies"
+    },
+    {
+      "name": "Interest Income"
+    },
+    {
+      "name": "Interfund Transfers"
+    },
+    {
+      "name": "Licenses & Permits"
+    },
+    {
+      "name": "Miscellaneous Revenue"
+    },
+    {
+      "name": "Parking Tax"
+    },
+    {
+      "name": "Property Tax"
+    },
+    {
+      "name": "Real Estate Transfer Tax"
+    },
+    {
+      "name": "Sales Tax"
+    },
+    {
+      "name": "Service Charges"
+    },
+    {
+      "name": "Transfers from Fund Balance"
+    },
+    {
+      "name": "Transient Occupancy Tax"
+    },
+    {
+      "name": "Utility Consumption Tax"
+    },
+    {
+      "name": "Housing & Community Development"
+    },
+    {
+      "name": "Gas Tax"
+    },
+    {
+      "name": "Internal Service Funds"
+    },
+    {
+      "name": "Local Tax"
+    },
+    {
+      "name": "General Fund"
+    },
+    {
+      "name": "Non-Discretionary"
+    }
+  ],
+  "links": [
+    {
+      "source": 38,
+      "target": 0,
+      "value": 1.252
+    },
+    {
+      "source": 38,
+      "target": 1,
+      "value": 16.1024
+    },
+    {
+      "source": 38,
+      "target": 2,
+      "value": 4.9034
+    },
+    {
+      "source": 38,
+      "target": 3,
+      "value": 1.9137
+    },
+    {
+      "source": 38,
+      "target": 4,
+      "value": 1.9156
+    },
+    {
+      "source": 38,
+      "target": 5,
+      "value": 4.1698
+    },
+    {
+      "source": 38,
+      "target": 6,
+      "value": 4.8559
+    },
+    {
+      "source": 38,
+      "target": 7,
+      "value": 22.4377
+    },
+    {
+      "source": 38,
+      "target": 8,
+      "value": 124.7475
+    },
+    {
+      "source": 38,
+      "target": 9,
+      "value": 4.7713
+    },
+    {
+      "source": 38,
+      "target": 10,
+      "value": 5.2234
+    },
+    {
+      "source": 38,
+      "target": 11,
+      "value": 10.2803
+    },
+    {
+      "source": 38,
+      "target": 12,
+      "value": 2.549
+    },
+    {
+      "source": 38,
+      "target": 13,
+      "value": 77.2006
+    },
+    {
+      "source": 38,
+      "target": 14,
+      "value": 15.662
+    },
+    {
+      "source": 38,
+      "target": 15,
+      "value": 11.2828
+    },
+    {
+      "source": 38,
+      "target": 16,
+      "value": 2.8819
+    },
+    {
+      "source": 38,
+      "target": 17,
+      "value": 0.0454
+    },
+    {
+      "source": 38,
+      "target": 18,
+      "value": 212.5089
+    },
+    {
+      "source": 19,
+      "target": 38,
+      "value": 71.5054
+    },
+    {
+      "source": 20,
+      "target": 38,
+      "value": 23.8335
+    },
+    {
+      "source": 21,
+      "target": 38,
+      "value": 0.1194
+    },
+    {
+      "source": 22,
+      "target": 38,
+      "value": 0.7405
+    },
+    {
+      "source": 23,
+      "target": 38,
+      "value": 14.9229
+    },
+    {
+      "source": 24,
+      "target": 38,
+      "value": 2.2107
+    },
+    {
+      "source": 25,
+      "target": 38,
+      "value": 0.7493
+    },
+    {
+      "source": 26,
+      "target": 38,
+      "value": 10.2113
+    },
+    {
+      "source": 27,
+      "target": 38,
+      "value": 169.3074
+    },
+    {
+      "source": 28,
+      "target": 38,
+      "value": 55.63
+    },
+    {
+      "source": 29,
+      "target": 38,
+      "value": 55.4251
+    },
+    {
+      "source": 30,
+      "target": 38,
+      "value": 46.8456
+    },
+    {
+      "source": 31,
+      "target": 38,
+      "value": 6.8025
+    },
+    {
+      "source": 32,
+      "target": 38,
+      "value": 16.4
+    },
+    {
+      "source": 33,
+      "target": 38,
+      "value": 50
+    },
+    {
+      "source": 39,
+      "target": 0,
+      "value": 38.4343
+    },
+    {
+      "source": 39,
+      "target": 1,
+      "value": 4.0636
+    },
+    {
+      "source": 39,
+      "target": 2,
+      "value": 9.6838
+    },
+    {
+      "source": 39,
+      "target": 4,
+      "value": 0.0675
+    },
+    {
+      "source": 39,
+      "target": 6,
+      "value": 12.5926
+    },
+    {
+      "source": 39,
+      "target": 7,
+      "value": 13.5228
+    },
+    {
+      "source": 39,
+      "target": 8,
+      "value": 10.8653
+    },
+    {
+      "source": 39,
+      "target": 34,
+      "value": 18.5454
+    },
+    {
+      "source": 39,
+      "target": 9,
+      "value": 1.9615
+    },
+    {
+      "source": 39,
+      "target": 10,
+      "value": 62.6754
+    },
+    {
+      "source": 39,
+      "target": 11,
+      "value": 16.9423
+    },
+    {
+      "source": 39,
+      "target": 12,
+      "value": 0.2937
+    },
+    {
+      "source": 39,
+      "target": 13,
+      "value": 263.7925
+    },
+    {
+      "source": 39,
+      "target": 14,
+      "value": 10.5757
+    },
+    {
+      "source": 39,
+      "target": 15,
+      "value": 17.5294
+    },
+    {
+      "source": 39,
+      "target": 16,
+      "value": 156.8086
+    },
+    {
+      "source": 39,
+      "target": 17,
+      "value": 27.1776
+    },
+    {
+      "source": 39,
+      "target": 18,
+      "value": 23.6575
+    },
+    {
+      "source": 20,
+      "target": 39,
+      "value": 4.7521
+    },
+    {
+      "source": 35,
+      "target": 39,
+      "value": 7.0609
+    },
+    {
+      "source": 21,
+      "target": 39,
+      "value": 58.1621
+    },
+    {
+      "source": 22,
+      "target": 39,
+      "value": 0.1915
+    },
+    {
+      "source": 23,
+      "target": 39,
+      "value": 135.5091
+    },
+    {
+      "source": 36,
+      "target": 39,
+      "value": 74.2976
+    },
+    {
+      "source": 24,
+      "target": 39,
+      "value": 15.4548
+    },
+    {
+      "source": 37,
+      "target": 39,
+      "value": 148.1487
+    },
+    {
+      "source": 25,
+      "target": 39,
+      "value": 36.7525
+    },
+    {
+      "source": 26,
+      "target": 39,
+      "value": 8.6796
+    },
+    {
+      "source": 27,
+      "target": 39,
+      "value": 4.2857
+    },
+    {
+      "source": 29,
+      "target": 39,
+      "value": 24.6465
+    },
+    {
+      "source": 30,
+      "target": 39,
+      "value": 121.437
+    },
+    {
+      "source": 31,
+      "target": 39,
+      "value": 45.3387
+    },
+    {
+      "source": 32,
+      "target": 39,
+      "value": 4.4727
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a few lines to write out the data for the Sankey Diagram as `graph.json`.  This makes it easier for to create new [d3js](https://d3js.org/) visualizations from the dataset, [like this](http://bl.ocks.org/micahstubbs/2d91de526f6d86c175751f834b629701):

[![oakland-particle-sankey-3](https://cloud.githubusercontent.com/assets/2119400/16899269/b749461e-4bb2-11e6-91e2-72a391eaac1e.gif)](http://bl.ocks.org/micahstubbs/2d91de526f6d86c175751f834b629701)
